### PR TITLE
#9 API 고급 - 지연 로딩과 성능 최적화

### DIFF
--- a/jpashop/build.gradle
+++ b/jpashop/build.gradle
@@ -30,8 +30,14 @@ dependencies {
 	// 외부 라이브러리는 그렇지 않기 떄문에 버전을 명시해 줘야 한다.
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
     // 파라미터 바인딩 된 거 출력해준다.
-	// 하지만 이런 라이브러리들은 개발 단계에서는 편한데 운영할 땐 고민을 해봐야 한다. 성능 테스트 필요하다.
+	// 하지만 이런 라이브러리들은 개발 단계에서는 편한데 운영할 땐 고민을 해봐야 한다. 성능 테스트가 필요하다.
 	// 성능을 저하시키는 병목이 될 수 있기 때문이다.
+
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
+	// 웬만한 라이브러리들은 스프링부트가 최적화된 버전을 알고 있어서 이에 맞게 알아서 해준다.
+	// 그래서 버전 생략 가능
+	// 하이버네이트가 만든 프록시 객체를 JSON으로 읽을 수 있도록 도와주는 역할.
+	//	기본적으로 초기화 된 프록시 객체만 노출, 초기화 되지 않은 프록시 객체는 노출 안함
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/jpashop/src/main/java/jpabook/jpashop/InitDb.java
+++ b/jpashop/src/main/java/jpabook/jpashop/InitDb.java
@@ -1,0 +1,99 @@
+package jpabook.jpashop;
+
+import jpabook.jpashop.domain.*;
+import jpabook.jpashop.domain.item.Book;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+
+/**
+ * * userA
+ *   * JPA1 BOOK
+ *   * JPA2 BOOK
+ * * userB
+ *   * SPRING1 BOOK
+ *   * SPRING2 BOOK
+ */
+
+// 서버가 뜰 때
+@Component // 컴프넌트 스캔의 대상이 되고
+@RequiredArgsConstructor
+public class InitDb {
+
+    private final InitService initService;
+
+    // 스프링 빈이 다 엮이고 나서 호출
+    @PostConstruct
+    public void init() {
+        initService.dbInit1(); // 애플리케이션 로딩 시점에 이를 호출하고 싶어서
+        initService.dbInit2();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+        private final EntityManager em;
+        public void dbInit1() {
+            Member member = createMember("userA", "서울", "1", "1111");
+            em.persist(member);
+
+            Book book1 = createBook("JPA1 Book", 10000, 100);
+            em.persist(book1);
+
+            Book book2 = createBook("JPA2 Book", 20000, 100);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 10000, 1);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+
+            Delivery delivery = createDelivery(member);
+
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        public void dbInit2() {
+            Member member = createMember("userB", "경기", "2", "2222");
+            em.persist(member);
+
+            Book book1 = createBook("SPRING1 Book", 20000, 200);
+            em.persist(book1);
+
+            Book book2 = createBook("SPRING2 Book", 40000, 300);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 20000, 3);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 40000, 4);
+
+            Delivery delivery = createDelivery(member);
+
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        private Delivery createDelivery(Member member) {
+            Delivery delivery = new Delivery();
+            delivery.setAddress(member.getAddress());
+            return delivery;
+        }
+
+        private Member createMember(String name, String city, String street, String zipcode) {
+            Member member = new Member();
+            member.setName(name);
+            member.setAddress(new Address(city, street, zipcode));
+            return member;
+        }
+
+        private Book createBook(String name, int price, int stockQuantity) {
+            Book book1 = new Book();
+            book1.setName(name);
+            book1.setPrice(price);
+            book1.setStockQuantity(stockQuantity);
+            return book1;
+        }
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -16,6 +16,9 @@ public class JpashopApplication {
 
 	@Bean
 	Hibernate5Module hibernate5Module() {
+		Hibernate5Module hibernate5Module = new Hibernate5Module(); //강제 지연 로딩 설정
+		hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, true);
+
 		return new Hibernate5Module();
 	}
 	// 지연로딩은 무시하고 진행하도록.

--- a/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop;
 
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication // 이 어노테이션이 있으면 해당 패키지와 이 패키지 하위에 있는 것들을 모두 스프링이 컴포넌트 스케일화 해
 // 스프링 빈에 자동 등록
@@ -12,4 +14,10 @@ public class JpashopApplication {
 		SpringApplication.run(JpashopApplication.class, args);
 	}
 
+	@Bean
+	Hibernate5Module hibernate5Module() {
+		return new Hibernate5Module();
+	}
+	// 지연로딩은 무시하고 진행하도록.
+	// Order 조회할 때 Memebr, Delivery는 LAZY로 되어 있으니까 Order만 조회
 }

--- a/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -16,8 +16,8 @@ public class JpashopApplication {
 
 	@Bean
 	Hibernate5Module hibernate5Module() {
-		Hibernate5Module hibernate5Module = new Hibernate5Module(); //강제 지연 로딩 설정
-		hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, true);
+//		Hibernate5Module hibernate5Module = new Hibernate5Module(); //강제 지연 로딩 설정
+//		hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, true);
 
 		return new Hibernate5Module();
 	}

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -54,6 +54,14 @@ public class OrderSimpleApiController {
                 .collect(Collectors.toList());
     }
 
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+        return orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .collect(Collectors.toList());
+    }
+
     @Data
     static class SimpleOrderDto {
         private Long orderId;

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -27,7 +27,7 @@ public class OrderSimpleApiController {
     public List<Order> ordersV1(){
         List<Order> all = orderRepository.findAllByString(new OrderSearch());
         // Order에 Member가 있어 Member로 가면 Member에 Order가 있어 또 Order로 가는 무한루프에 빠진다.
-        // 양방향 연관관계 문제가 생긴다. 
+        // 양방향 연관관계 문제가 생긴다.
         return all;
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -28,6 +28,12 @@ public class OrderSimpleApiController {
         List<Order> all = orderRepository.findAllByString(new OrderSearch());
         // Order에 Member가 있어 Member로 가면 Member에 Order가 있어 또 Order로 가는 무한루프에 빠진다.
         // 양방향 연관관계 문제가 생긴다.
+
+        for (Order order : all) {
+            order.getMember().getName(); // Lazy 강제 초기화
+            order.getDelivery().getAddress(); // Lazy 강제 초기환
+        }
+        
         return all;
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -4,9 +4,9 @@ import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
-import jpabook.jpashop.repository.SimpleOrderQueryDto;
+import jpabook.jpashop.repository.order.simplequery.SimpleOrderQueryDto;
+import jpabook.jpashop.repository.order.simplequery.SimpleOrderQueryRepository;
 import lombok.Data;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 public class OrderSimpleApiController {
 
     private final OrderRepository orderRepository;
+    private final SimpleOrderQueryRepository simpleOrderQueryRepository;
 
     @GetMapping("/api/v1/simple-orders")
     public List<Order> ordersV1() {
@@ -65,7 +66,8 @@ public class OrderSimpleApiController {
 
     @GetMapping("/api/v4/simple-orders")
     public List<SimpleOrderQueryDto> ordersV4() {
-        return orderRepository.findOrderDtos();
+        return simpleOrderQueryRepository.findOrderDtos();
+        // 리포지토리는 가급적이면 순수한 엔티티를 조회하는 데 쓰인다.
     }
     // 재사용성은 v3가 더 좋다. v4는 화면에는 최적화되지만 재사용성이 없다.
         // 리포지토리: 엔티티의 객체 그래프를 조회할 때 사용되는 것.

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,14 +1,20 @@
 package jpabook.jpashop.api;
 
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jpabook.jpashop.domain.Order;
+
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * xToOne
@@ -24,7 +30,7 @@ public class OrderSimpleApiController {
     private final OrderRepository orderRepository;
 
     @GetMapping("/api/v1/simple-orders")
-    public List<Order> ordersV1(){
+    public List<Order> ordersV1() {
         List<Order> all = orderRepository.findAllByString(new OrderSearch());
         // Order에 Member가 있어 Member로 가면 Member에 Order가 있어 또 Order로 가는 무한루프에 빠진다.
         // 양방향 연관관계 문제가 생긴다.
@@ -33,7 +39,35 @@ public class OrderSimpleApiController {
             order.getMember().getName(); // Lazy 강제 초기화
             order.getDelivery().getAddress(); // Lazy 강제 초기환
         }
-        
+
         return all;
+    }
+
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> ordersV2() {
+        // ORDER 2개
+        // 1 + N + N 문제 (최악의 경우; 서로 다른 유저일 때)
+        // 지연로딩은 영속성 컨텍스트에서 조회하기 때문에 서로 같은 유저라면 보내지는 쿼리가 1 + N + N 보다 적을 수도 있다.
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+        return orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .collect(Collectors.toList());
+    }
+
+    @Data
+    static class SimpleOrderDto {
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+
+        public SimpleOrderDto(Order order) { // DTO가 Entity를 파라미터로 받는 건 크게 문제되지 않는다.
+            orderId = order.getId();
+            name = order.getMember().getName(); // LAZY 초기화
+            orderDate  = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress(); // LAZY 초기화
+        }
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,0 +1,33 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.OrderSearch;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jpabook.jpashop.domain.Order;
+import java.util.List;
+
+/**
+ * xToOne
+ *
+ * Order
+ * Order -> Member (ManyToOne)
+ * Order -> Delivery (OneToOne)
+ */
+@RestController
+@RequiredArgsConstructor
+public class OrderSimpleApiController {
+
+    private final OrderRepository orderRepository;
+
+    @GetMapping("/api/v1/simple-orders")
+    public List<Order> ordersV1(){
+        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+        // Order에 Member가 있어 Member로 가면 Member에 Order가 있어 또 Order로 가는 무한루프에 빠진다.
+        // 양방향 연관관계 문제가 생긴다. 
+        return all;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -4,6 +4,7 @@ import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import jpabook.jpashop.repository.SimpleOrderQueryDto;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +62,21 @@ public class OrderSimpleApiController {
                 .map(o -> new SimpleOrderDto(o))
                 .collect(Collectors.toList());
     }
+
+    @GetMapping("/api/v4/simple-orders")
+    public List<SimpleOrderQueryDto> ordersV4() {
+        return orderRepository.findOrderDtos();
+    }
+    // 재사용성은 v3가 더 좋다. v4는 화면에는 최적화되지만 재사용성이 없다.
+        // 리포지토리: 엔티티의 객체 그래프를 조회할 때 사용되는 것.
+        // 근데 API 스펙에 맞게 리포지토리 코드가 만들어져버린 상황.
+        // 리포지토리가 화면에 의존하게 되는, 논리적으로 계층이 깨지는 상황.
+    // 코드도 v3이 더 깔끔하다.
+    // v3보다 v4가 select 절이 더 간결하다. 네트워크를 덜 사용한다.
+        // 성능 테스트를 직접 해보는 게 맞다.
+        // 하지만 대개 성능 개선은 from, where 절에서 많이 일어나는 것이지 select 절에서의 성능 개선은 큰 영향을 미치지 않는다.
+        // select 절의 필드가 수십 개인 경우라면 그땐 고민을 해보는 게 좋다.
+    // tradeoff가 있다.
 
     @Data
     static class SimpleOrderDto {

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,6 +17,7 @@ public class Delivery {
     private Long id; // 객체는 클래스가 있으니까 그냥 id로 써주면 되는데
     // 테이블을 만들 F게 되면 그렇지 않으니까 외래키 쓰는 경우와 맞춰서 어느 테이블의 id인지 함께 써주는 게 좋다
 
+    @JsonIgnore
     @OneToOne(mappedBy = "delivery", fetch = LAZY) // 연관관계의 거울
     private Order order;
 

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
@@ -31,6 +31,7 @@ public class Member {
     // 다양한 API를 개발하게 될 테고, 어떤 API는 이를 필요로 하고 어떤 API는 그렇지 않다.
     // 그러므로 이를 @JsonIgnore를 이용해서 Entity 단에서 처리하는 건 좋지 않다. 문제가 발생한다.
     // 무엇보다 Entity에 프레젠테이션 계층에서 해야 할 일이 첨가되는 것은 좋지 않다.
+    @JsonIgnore // 양방향 연관관계가 있으면 둘 중 한 쪽에 @JsonIgnore
     @OneToMany(mappedBy = "member") // '연관관계의 주인이 아닌 거울이다'
     private List<Order> orders = new ArrayList<>(); // 초기화를 생성자에서 해줄 수도 있지만 이게 best practice
     // null 문제에서 안전

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Order.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Order.java
@@ -28,12 +28,16 @@ public class Order {
     private Long id;
 
     // (fetch = FetchType.LAZY)
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY) // 지연로딩이기에 new 해서 db에서 member 객체 바로 안 가져오고 order 데이터만 가져온다.
+    // 근데 그렇다고 null은 넣어둘 수 없으니 hibernate가 Proxy라이브러리를 사용해 Member를 상속받는 ProxyMember를 객체를 생성해 넣어둔다.
+    // 프록시 기술을 쓸 때 bytebuddy 라이브러리를 많이 써서 오류 로그에 ByteBuddyInterception이 찍히게 된다.
+    // 이렇게 있다가 멤버 객체를 다룰 일이 생기면 그때 디비 멤버 객체 sql을 보내 멤버 객체 값으로 채워준다. (프록시 초기화)
     @JoinColumn(name = "member_id") // FK 이름이 member_id
     private Member member;
 
     // cascade = CascadeType.ALL
     @OneToMany(mappedBy = "order", cascade = ALL) // persist 전파, delete할 때 같이 지움
+    // 기본이 LAZY라 세팅 안 함.
     private List<OrderItem> orderItems = new ArrayList<>();
 
 

--- a/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jpabook.jpashop.domain.item.Item;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,6 +24,7 @@ public class OrderItem {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
+    @JsonIgnore
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "order_id")
     private Order order;

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -101,6 +101,16 @@ public class OrderRepository {
         return query.getResultList();
     }
 
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery(
+                "select o from Order o" +
+                        " join fetch o.member m" + // order를 가져올 때 member 객체 그래프도 한 번에 같이 가져온다.
+                        " join fetch o.delivery d", Order.class // join이면서 select 절에서 같이 가져온다
+                // fetch join: member, delivery가 LAZY이지만 이를 무시하고 프록시도 아니고 값을 모두 채워 가져온다.
+                // fetch: SQL에는 없고 JPA에만 있는 문법
+        ).getResultList();
+    }
+
     /**
      * QueryDsl
      */

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -111,6 +111,17 @@ public class OrderRepository {
         ).getResultList();
     }
 
+    public List<SimpleOrderQueryDto> findOrderDtos() {
+        return em.createQuery(
+                // 엔티티를 넘기면 엔티티의 식별자가 넘어가서 엔티티로 넘기면 안된다.
+                "select new jpabook.jpashop.repository.SimpleOrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address)" +
+                        " from Order o" +
+                        " join o.member m" +
+                        " join o.delivery d", SimpleOrderQueryDto.class)
+                .getResultList();
+        // 기본적으로 JPA는 Entity나 Value Object만 반환할 수 있다.
+    }
+
     /**
      * QueryDsl
      */

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -1,10 +1,10 @@
 package jpabook.jpashop.repository;
 
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.repository.order.simplequery.SimpleOrderQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
-import org.thymeleaf.model.IStandaloneElementTag;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
@@ -110,19 +110,4 @@ public class OrderRepository {
                 // fetch: SQL에는 없고 JPA에만 있는 문법
         ).getResultList();
     }
-
-    public List<SimpleOrderQueryDto> findOrderDtos() {
-        return em.createQuery(
-                // 엔티티를 넘기면 엔티티의 식별자가 넘어가서 엔티티로 넘기면 안된다.
-                "select new jpabook.jpashop.repository.SimpleOrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address)" +
-                        " from Order o" +
-                        " join o.member m" +
-                        " join o.delivery d", SimpleOrderQueryDto.class)
-                .getResultList();
-        // 기본적으로 JPA는 Entity나 Value Object만 반환할 수 있다.
-    }
-
-    /**
-     * QueryDsl
-     */
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/SimpleOrderQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/SimpleOrderQueryDto.java
@@ -1,0 +1,26 @@
+package jpabook.jpashop.repository;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SimpleOrderQueryDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    public SimpleOrderQueryDto(Long orderId, String name, LocalDateTime
+            orderDate, OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate  = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/SimpleOrderQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/SimpleOrderQueryDto.java
@@ -1,4 +1,4 @@
-package jpabook.jpashop.repository;
+package jpabook.jpashop.repository.order.simplequery;
 
 import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.Order;

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/SimpleOrderQueryRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/SimpleOrderQueryRepository.java
@@ -1,0 +1,31 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SimpleOrderQueryRepository {
+
+    private final EntityManager em;
+
+    // 화면에 dependent한 게 리포지토리에 있으면 용도가 애매해진다.
+    // 별도로 분리해 관리하는 게 유지보수에 훨씬 좋다.
+
+    // 조회 전용으로 화면에 맞춰 쓰는 함수
+    public List<SimpleOrderQueryDto> findOrderDtos() {
+        return em.createQuery(
+                        "select new jpabook.jpashop.repository.order.simplequery.SimpleOrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address)" +
+                                " from Order o" +
+                                " join o.member m" +
+                                " join o.delivery d", SimpleOrderQueryDto.class)
+                .getResultList();
+    }
+}
+// v4까지 했는데도 성능 개선이 더 필요하거나 디비에서 제공하는 네이티브한 기능을 써야 할 때는
+// JPA가 제공하는 네이티브 SQL이나
+// queryRepository에서 entity manager가 아니라 직접 데이터베이스 커넥션을 받거나 스프링 JDBC Template을 사용해서
+// SQL을 직접 사용한다.

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -7,7 +7,8 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
+    # create : 애플리케이션 실행 시점에 테이블 드롭하고 다시 만든다.
     properties:
       hibernate:
         #        show_sql: true


### PR DESCRIPTION
## Overview
- 주문 + 배송 정보 + 회원 조회 API 성능 최적화
  - 지연 로딩으로 발생하는 문제를 단계적으로 해결

## Contents
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- `v1`
  - 양방향 연관관계가 있어 무한 루프에 빠진다. -> 한 쪽에 `@JsonIgnore`를 작성해준다. 
  - 지연로딩으로 설정해 두었기에 실제 엔티티 대신 프록시 객체로 채워진다. -> `Hibernate5Module.Feature.FORCE_LAZY_LOADING` 혹은 컨트롤러에서 for문을 통해 강제 초기화한다.
  - 엔티티를 직접 노출하고 있기에 엔티티 변경 시 API 스펙에 영향을 미치는 문제점이 있다. 
- `v2`: DTO 도입을 통한 엔티티 노출 지양
  - 문제점: 지연 로딩 원리에 따라 쿼리 조회 횟수가 최악의 경우 1 + N + N이 되는 문제가 있다.
    - `최악의 경우`인 이유: 지연 로딩은 기본적으로 영속성 컨텍스트 안에서 조회를 하기에 그 안에서 조회가 가능한 경우 쿼리를 생략하기 때문이다.
- `v3`: DTO 도입 및 페치 조인을 통한 최적화
  - fetch join: 지연 로딩으로 설정되어 있더라도 프록시 객체가 아닌 실제 엔티티 객체로 채워 데이터를 가져오게 된다.
  - 쿼리가 1번만 호출되는 것을 확인할 수 있다. 
- `v4`: JPA에서 DTO로 바로 조회
  - 쿼리의 select 절에서 엔티티가 아닌 DTO 관련 코드를 추가함으로써 DTO로 바로 조회 
  - 장점: 화면에 필요한 데이터만 가져옴에 따라 네트워크를 덜 사용하게 된다. (필드가 수십 개인 경우라면 유의미하지만 그렇지 않다면 그 영향이 미비하다.)
  - 단점: 
    - 코드가 덜 간결해진다. 
    - 화면에는 최적화되지만 이에 따라 재사용성이 떨어진다. 
    - Repository: 엔티티의 객체 그래프를 조회할 때 사용되는 것인데 Repository에 해당 코드를 작성하면 계층 분리가 논리적으로 깨지게 된다. -> 해당 코드만 따로 분리해 담는 repository를 만들어 사용하면 이를 해결할 수 있다. 
- 추가적인 성능 개선이 필요한 경우엔 `JPA가 제공하는 네이티브 SQL`이나 entity manager가 아니라 직접 데이터베이스 커넥션을 받거나 스프링 JDBC Template을 사용해서 SQL을 직접 다룬다. 

## 📸 
<!-- gif or mp4 용량 제한 있음 -->

## Related Issue
- Resolved: #9

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->