### PR TITLE
#11 API 고급 - 컬렉션 조회 최적화

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -5,6 +5,8 @@ import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.OrderItem;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.order.query.OrderQueryDto;
+import jpabook.jpashop.repository.order.query.OrderQueryRepository;
 import jpabook.jpashop.repository.OrderSearch;
 import lombok.Data;
 import lombok.Getter;
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
 public class OrderApiController {
 
     private final OrderRepository orderRepository;
+    private final OrderQueryRepository orderQueryRepository;
 
     @GetMapping("/api/v1/orders")
     public List<Order> ordersV1() {
@@ -78,6 +81,11 @@ public class OrderApiController {
                 .collect(Collectors.toList());
 
         return result;
+    }
+
+    @GetMapping("/api/v4/orders")
+    public List<OrderQueryDto> ordersV4() {
+        return orderQueryRepository.findOrderQueryDtos();
     }
 
     @Data

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -5,6 +5,7 @@ import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.OrderItem;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.order.query.OrderFlatDto;
 import jpabook.jpashop.repository.order.query.OrderQueryDto;
 import jpabook.jpashop.repository.order.query.OrderQueryRepository;
 import jpabook.jpashop.repository.OrderSearch;
@@ -93,6 +94,12 @@ public class OrderApiController {
         return orderQueryRepository.findAllByDto_optimization();
     }
 
+    // 장점: 쿼리 한 번으로 동작된다.
+    // 단점: 의도한 대로의 페이징이 불가하다. 
+    @GetMapping("/api/v6/orders")
+    public List<OrderFlatDto> ordersV6() {
+        return orderQueryRepository.findAllByDto_flat();
+    }
 
     @Data
     static class OrderDto {

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -1,14 +1,21 @@
 package jpabook.jpashop.api;
 
+import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.OrderItem;
+import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import lombok.Data;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,7 +31,7 @@ public class OrderApiController {
         for (Order order : all) {
             order.getMember().getName();
             order.getDelivery().getAddress();
-            
+
             List<OrderItem> orderItems = order.getOrderItems();
             orderItems.stream().forEach(o -> o.getItem().getName());
 //            for (OrderItem orderItem : orderItems) {
@@ -32,5 +39,36 @@ public class OrderApiController {
 //            }
         }
         return all;
+    }
+
+    @GetMapping("/api/v2/orders")
+    public List<OrderDto> ordersV2() {
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+        List<OrderDto> collect = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+        return collect;
+    }
+
+    @Data
+    static class OrderDto {
+
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+        private List<OrderItem> orderItems; 
+        public OrderDto(Order order) {
+            orderId = order.getId();
+            name = order.getMember().getName();
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress();
+
+            // 프록시 강제 초기화
+            order.getOrderItems().stream().forEach(o -> o.getItem().getName());
+            orderItems = order.getOrderItems();
+        }
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -31,6 +31,8 @@ public class OrderApiController {
     private final OrderRepository orderRepository;
     private final OrderQueryRepository orderQueryRepository;
 
+    // 엔티티를 조회해 엔티티로 반환
+    // 엔티티 스펙이 변하면 API 스펙도 변하기에 사용하면 안되는 방식
     @GetMapping("/api/v1/orders")
     public List<Order> ordersV1() {
         List<Order> all = orderRepository.findAllByString(new OrderSearch());
@@ -49,6 +51,7 @@ public class OrderApiController {
         return all;
     }
 
+    // 엔티티를 조회해 DTO로 반환
     @GetMapping("/api/v2/orders")
     public List<OrderDto> ordersV2() {
         List<Order> orders = orderRepository.findAllByString(new OrderSearch());
@@ -59,6 +62,9 @@ public class OrderApiController {
         return result;
     }
 
+    // 엔티티를 조회해 DTO로 반환
+    // 쿼리 수 최적화 + 페이징 X
+    // 컬렉션까지 한 번에 fetch join
     @GetMapping("/api/v3/orders")
     public List<OrderDto> ordersV3() {
         List<Order> orders = orderRepository.findAllWithItem();
@@ -73,6 +79,10 @@ public class OrderApiController {
         return result;
     }
 
+    // 엔티티를 조회해 DTO로 반환
+    // 쿼리 수 최적화 + 페이징 O
+    // toOne 관계는 fetch join으로 쿼리 수 최적화
+    // 컬렉션은 fetch join에서 제외(지연 로딩 유지) in 쿼리로 가져옴 -> 페이징 가능
     @GetMapping("/api/v3.1/orders")
     public List<OrderDto> ordersV3_page(
             @RequestParam(value = "offset", defaultValue = "0") int offset,
@@ -87,16 +97,22 @@ public class OrderApiController {
         return result;
     }
 
+    // JPA에서 DTO로 직접 조회해 DTO로 반환
+       // 엔티티로 조회하는 방식 때와는 다르게 성능 최적화 혹은 최적화 방식 변경 시 많은 양의 코드 수정 필요
     @GetMapping("/api/v4/orders")
     public List<OrderQueryDto> ordersV4() {
         return orderQueryRepository.findOrderQueryDtos();
     }
 
+    // JPA에서 DTO로 직접 조회해 DTO로 반환
+    // 루트 조회 + 컬렉션 부분은 in 절로 따로 조회 및 채우기
     @GetMapping("/api/v5/orders")
     public List<OrderQueryDto> ordersV5() {
         return orderQueryRepository.findAllByDto_optimization();
     }
 
+    // JPA에서 DTO로 직접 조회해 DTO로 반환
+    // 모든 필드를 조인해서 한 번에 가져오기
     // 장점: 쿼리 한 번으로 동작된다.
     // 단점: 의도한 대로의 페이징이 불가하다.
     @GetMapping("/api/v6/orders")

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -1,0 +1,36 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderItem;
+import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.OrderSearch;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderApiController {
+
+    private final OrderRepository orderRepository;
+
+    @GetMapping("/api/v1/orders")
+    public List<Order> ordersV1() {
+        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+
+        // 프록시 강제 초기화
+        for (Order order : all) {
+            order.getMember().getName();
+            order.getDelivery().getAddress();
+            
+            List<OrderItem> orderItems = order.getOrderItems();
+            orderItems.stream().forEach(o -> o.getItem().getName());
+//            for (OrderItem orderItem : orderItems) {
+//                orderItem.getItem().getName();
+//            }
+        }
+        return all;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -44,10 +44,11 @@ public class OrderApiController {
     @GetMapping("/api/v2/orders")
     public List<OrderDto> ordersV2() {
         List<Order> orders = orderRepository.findAllByString(new OrderSearch());
-        List<OrderDto> collect = orders.stream()
+        List<OrderDto> result = orders.stream()
                 .map(o -> new OrderDto(o))
                 .collect(Collectors.toList());
-        return collect;
+
+        return result;
     }
 
     @Data
@@ -58,17 +59,33 @@ public class OrderApiController {
         private LocalDateTime orderDate;
         private OrderStatus orderStatus;
         private Address address;
-        private List<OrderItem> orderItems; 
+        private List<OrderItemDto> orderItems;
+        // List<OrderItem>이면 DTO 안에 엔티티가 있는 상황.
+        // 엔티티에 대한 의존을 완전히 끊어야 한다.
+        // OrderItem도 DTO로 바꿔야 한다.
+
         public OrderDto(Order order) {
             orderId = order.getId();
             name = order.getMember().getName();
             orderDate = order.getOrderDate();
             orderStatus = order.getStatus();
             address = order.getDelivery().getAddress();
+            orderItems = order.getOrderItems().stream()
+                    .map(orderItem -> new OrderItemDto(orderItem))
+                    .collect(Collectors.toList());
+        }
+    }
 
-            // 프록시 강제 초기화
-            order.getOrderItems().stream().forEach(o -> o.getItem().getName());
-            orderItems = order.getOrderItems();
+    @Getter
+    static class OrderItemDto {
+
+        private String itemName;
+        private int orderPrice;
+        private int count;
+        public OrderItemDto(OrderItem orderItem) {
+            itemName = orderItem.getItem().getName();
+            orderPrice = orderItem.getOrderPrice();
+            count = orderItem.getCount();
         }
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -58,6 +59,20 @@ public class OrderApiController {
         for (Order order : orders) {
             System.out.println("order ref="+ order + " id="+ order.getId());
         }
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+    @GetMapping("/api/v3.1/orders")
+    public List<OrderDto> ordersV3_page(
+            @RequestParam(value = "offset", defaultValue = "0") int offset,
+            @RequestParam(value = "limit", defaultValue = "100") int limit
+    ) {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery(offset, limit);
+        // orders와 관련된 컬렉션을 in 쿼리로 가져온다.
         List<OrderDto> result = orders.stream()
                 .map(o -> new OrderDto(o))
                 .collect(Collectors.toList());

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -51,6 +51,20 @@ public class OrderApiController {
         return result;
     }
 
+    @GetMapping("/api/v3/orders")
+    public List<OrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithItem();
+
+        for (Order order : orders) {
+            System.out.println("order ref="+ order + " id="+ order.getId());
+        }
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
     @Data
     static class OrderDto {
 

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -88,6 +88,12 @@ public class OrderApiController {
         return orderQueryRepository.findOrderQueryDtos();
     }
 
+    @GetMapping("/api/v5/orders")
+    public List<OrderQueryDto> ordersV5() {
+        return orderQueryRepository.findAllByDto_optimization();
+    }
+
+
     @Data
     static class OrderDto {
 

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -113,8 +113,11 @@ public class OrderRepository {
 
     public List<Order> findAllWithItem() {
         return em.createQuery(
-                        // 참조 값까지 동일하게 두 배로 나온다.
-                "select o from Order o" +
+                // distinct를 쓰지 않으면 참조 값까지 동일하게 두 배로 나온다.
+                // distinct를 쓰면 해결이 된다.
+                // 디비의 distinct와는 다르다. 디비의 distinct는 모든 컬럼 값이 똑같아야만 적용이 된다.
+                // JPA의 distinct는 디비에 distinct 키워드를 붙여주는 것 + 추가적인 일을 해준다. 엔티티의 id가 같으면 자체적으로 중복을 제거해준다.
+                "select distinct o from Order o" +
                         " join fetch o.member m" +
                         " join fetch o.delivery d" +
                         " join fetch o.orderItems oi" +

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -122,6 +122,15 @@ public class OrderRepository {
                         " join fetch o.delivery d" +
                         " join fetch o.orderItems oi" +
                         " join fetch oi.item i", Order.class)
+                // 단 1대다에서 fetch join을 하면 페이징 불가능하다.
+                .setFirstResult(1)
+                .setMaxResults(100)
+                // warning이 뜬다. 디비 쿼리 단계에서는 1대다에서 '다' 기준으로 데이터가 늘어나버리니
+                // 제대로 페이징을 할 수 없어 메모리에서 페이징 처리를 해 버린다.
+                // 데이터가 많을 경우엔 out of memory 문제가 발생하게 된다.
+
+                // + 컬렉션 fetch join은 1개만 사용 가능하다.
+                // 둘 이상에 사용하면 데이터가 매우 큰 폭으로 늘어나며 부정합 문제가 발생한다.
                 .getResultList();
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -111,6 +111,20 @@ public class OrderRepository {
         ).getResultList();
     }
 
+    public List<Order> findAllWithMemberDelivery(int offset, int limit) {
+        // Order를 기준으로 toOne으로 걸린 것들은 fetch join으로 가져오기
+        return em.createQuery(
+                "select o from Order o" + // 여기까지만 써줘도 된다. 모두 in 쿼리 방식으로 변경된다.
+                        // 하지만 그만큼 네트워크를 더 많이 쓰게 되는 거니까 toOne은 그냥 join fetch로 써주는 게 좋다.
+                        " join fetch o.member m" +
+                        " join fetch o.delivery d", Order.class
+        )
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .getResultList();
+        // toOne 관계에 fetch join한 것은 페이징 적용이 잘 된다.
+    }
+
     public List<Order> findAllWithItem() {
         return em.createQuery(
                 // distinct를 쓰지 않으면 참조 값까지 동일하게 두 배로 나온다.
@@ -123,8 +137,8 @@ public class OrderRepository {
                         " join fetch o.orderItems oi" +
                         " join fetch oi.item i", Order.class)
                 // 단 1대다에서 fetch join을 하면 페이징 불가능하다.
-                .setFirstResult(1)
-                .setMaxResults(100)
+//                .setFirstResult(1)
+//                .setMaxResults(100)
                 // warning이 뜬다. 디비 쿼리 단계에서는 1대다에서 '다' 기준으로 데이터가 늘어나버리니
                 // 제대로 페이징을 할 수 없어 메모리에서 페이징 처리를 해 버린다.
                 // 데이터가 많을 경우엔 out of memory 문제가 발생하게 된다.

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -110,4 +110,15 @@ public class OrderRepository {
                 // fetch: SQL에는 없고 JPA에만 있는 문법
         ).getResultList();
     }
+
+    public List<Order> findAllWithItem() {
+        return em.createQuery(
+                        // 참조 값까지 동일하게 두 배로 나온다.
+                "select o from Order o" +
+                        " join fetch o.member m" +
+                        " join fetch o.delivery d" +
+                        " join fetch o.orderItems oi" +
+                        " join fetch oi.item i", Order.class)
+                .getResultList();
+    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderFlatDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderFlatDto.java
@@ -1,0 +1,34 @@
+package jpabook.jpashop.repository.order.query;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// SQL 조인의 결과를 그대로 가져올 수 있도록 데이터 구조를 맞춰주기 위해 필요한 Dto
+@Data
+public class OrderFlatDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    private String itemName;
+    private int orderPrice;
+    private int count;
+
+    public OrderFlatDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address, String itemName, int orderPrice, int count) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderItemQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderItemQueryDto.java
@@ -1,0 +1,21 @@
+package jpabook.jpashop.repository.order.query;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+@Data
+public class OrderItemQueryDto {
+
+    @JsonIgnore // Entity가 아니라 Dto니까 JsonIgnore 편하게 써도 괜찮다.
+    private Long orderId;
+    private String itemName;
+    private int orderPrice;
+    private int count;
+
+    public OrderItemQueryDto(Long orderId, String itemName, int orderPrice, int count) {
+        this.orderId = orderId;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
@@ -1,0 +1,30 @@
+package jpabook.jpashop.repository.order.query;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class OrderQueryDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+    private List<OrderItemQueryDto> orderItems;
+
+    public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address
+//            , List<OrderItemQueryDto> orderItems
+    ) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+//        this.orderItems = orderItems;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
@@ -3,11 +3,13 @@ package jpabook.jpashop.repository.order.query;
 import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.OrderStatus;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(of = "orderId") // 중복 제거 시 묶는 기준
 public class OrderQueryDto {
 
     private Long orderId;
@@ -17,14 +19,23 @@ public class OrderQueryDto {
     private Address address;
     private List<OrderItemQueryDto> orderItems;
 
+    // 컬렉션 미포함
     public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address
-//            , List<OrderItemQueryDto> orderItems
     ) {
         this.orderId = orderId;
         this.name = name;
         this.orderDate = orderDate;
         this.orderStatus = orderStatus;
         this.address = address;
-//        this.orderItems = orderItems;
+    }
+
+    // 컬렉션 포함
+    public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address, List<OrderItemQueryDto> orderItems) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+        this.orderItems = orderItems;
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
@@ -85,5 +85,15 @@ public class OrderQueryRepository {
                 // toOne 관계는 조인을 해도 데이터의 row 수가 증가하지 않아 toOne 관계들은 join 해서 최적화하여 조회
         ).getResultList();
     }
-    
+
+    // Order와 OrderItem, OrderItem과 Item을 조인해서 한 번에 가져오는 방식
+    public List<OrderFlatDto> findAllByDto_flat() {
+        return em.createQuery("select new jpabook.jpashop.repository.order.query.OrderFlatDto(o.id, m.name, o.orderDate, o.status, d.address, i.name, oi.orderPrice, oi.count)" +
+                " from Order o" +
+                " join o.member m"+
+                " join o.delivery d" +
+                " join o.orderItems oi"+
+                " join oi.item i ", OrderFlatDto.class)
+                .getResultList();
+    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
@@ -1,0 +1,50 @@
+package jpabook.jpashop.repository.order.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepository {
+
+    private final EntityManager em;
+
+    public List<OrderQueryDto> findOrderQueryDtos() {
+        // 기존에 controller에 만들어 둔 OrderDto를 쓰게 되면 Repository가 Controller를 참조하게 되는 순환 관계 만들어지게 된다.
+        List<OrderQueryDto> result = findOrders(); // query 1번 -> N개 파생 : N + 1 문제 발생
+        // 컬렉션 아닌 것들은 바로 가져오고
+
+        // 컬렉션에 해당하는 건 forEach 루프를 돌려 직접 채우기
+        // toMany 관계는 조인하면 row 수가 증가하기 때문에 findOrders에서 join해서 가져오지 않은 것.
+        // findOrderItems 라는 별도의 메서드로 조회
+        result.forEach(o -> {
+            List<OrderItemQueryDto> orderItems = findOrderItems(o.getOrderId()); // 파생된 query N번.
+            o.setOrderItems(orderItems);
+        });
+
+        return result;
+    }
+
+    private List<OrderItemQueryDto> findOrderItems(Long orderId) {
+        return em.createQuery(
+                "select new jpabook.jpashop.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count)" +
+                        " from OrderItem oi" +
+                        " join oi.item i" + // OrderItem 입장에서 item은 toOne 관계라서 join 해도 괜찮다.
+                        " where oi.order.id = :orderId", OrderItemQueryDto.class
+        ).setParameter("orderId", orderId)
+                .getResultList();
+    }
+
+    private List<OrderQueryDto> findOrders() {
+        return em.createQuery(
+                "select new jpabook.jpashop.repository.order.query.OrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address)" +
+                        " from Order o" +
+                        " join o.member m" +
+                        " join o.delivery d", OrderQueryDto.class
+                // toOne 관계는 조인을 해도 데이터의 row 수가 증가하지 않아 toOne 관계들은 join 해서 최적화하여 조회
+        ).getResultList();
+    }
+}

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
         # global하게 적용시키는 값이고, 디테일에 하고 싶다면 Entity BatchSize를 직접 지정해줄 수 있다.
         # toOne 관계면 Entity의 필드에.
         # 하지만 보통 주로 global하게 설정하여 적용한다.
+        # 100 ~ 1000 이 적당. 크게 잡을 수록 DB에 가해지는 순간 부하가 크며, 작게 할 수록 전송되는 쿼리의 수와 대기 시간이 증가한다.
+        # 100 정도로 두고 조금씩 늘리며 테스트해 보는 것이 좋다.
+        # 메모리 사용량은 batch fetch size에 상관 없이 동일하다. 애플리케이션은 루프를 돌려 결국엔 전체 데이터를 로딩해야 하기 때문이다. 
 logging.level:
   org.hibernate.SQL: debug
 #  org.hibernate.type: trace

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -13,8 +13,12 @@ spring:
       hibernate:
         #        show_sql: true
         format_sql: true
-        default_batch_fetch_size: 1000 #최적화 옵션
-
+        default_batch_fetch_size: 100 # 최적화 옵션
+        # in 쿼리의 개수를 몇 개로 할 것인지 루프 돌려 모두 가져올 건데 한 루프에서 몇 개를 가져올 것인지.
+        # 따로 따로 처리하던 lazy loading을 한 번에 처리 가능. 1 + N + M 이 1 + 1 + 1이 됨
+        # global하게 적용시키는 값이고, 디테일에 하고 싶다면 Entity BatchSize를 직접 지정해줄 수 있다.
+        # toOne 관계면 Entity의 필드에.
+        # 하지만 보통 주로 global하게 설정하여 적용한다.
 logging.level:
   org.hibernate.SQL: debug
 #  org.hibernate.type: trace


### PR DESCRIPTION
## Overview
- 주문내역 조회 기능에 추가로 `일대다 관계`인 주문한 상품 정보를 조회하고 성능을 최적화한다.

## Contents
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- v1
  - 엔티티로 조회, 엔티티로 반환
  - 한계: 엔티티의 스펙이 변하면 API 스펙도 변하게 된다.
- v2
  - 엔티티 조회, DTO로 반환
  - v1의 한계를 해결한다.
- v3
  - 엔티티 조회, DTO로 반환 + 쿼리 수 최적화
  - 모든 데이터를 fetch join하여 가져온다.
  - JPA의 distinct : SQL에 distinct 키워드 추가 + 동일 id를 갖는 엔티티들 중복 제거
  - 한계: 페이징이 불가하다. 
  - 쿼리: 1번
- v3.1
  - 엔티티 조회, DTO로 반환 + 쿼리 수 최적화 + 페이징
  - toOne 관계인 루트는 fetch join을 이용해 가져오고
  - toMany 관계인 컬렉션은 fetch join에서 제외해 지연로딩으로 조회한다.
  - 지연 로딩 성능 최적화:  hibernate.default_batch_fetch_size(글로벌 설정), @BatchSize(개별 설정)
    - 컬렉션이나 프록시 객체를 한 번에 설정한 size만큼 in 쿼리로 조회
    - default_batch_fetch_size: 
      - in 쿼리의 개수를 몇 개로 할 것인지, 루프 돌려 결국엔 모두 가져올 건데 한 루프에서 몇 개를 가져올 것인지
      - 100 ~ 1000 이 적당하다. 크게 잡을수록 DB에 가해지는 순간 부하가 크며, 작게 할수록 전송되는 쿼리의 수와 대기 시간이 증가한다.
  - 쿼리: 루트 1번, 컬렉션 1번
- v4
  - JPA에서 DTO로 직접 조회해 DTO로 반환
  - toOne 관계인 루트는 바로 조회
  - toMany 관계인 컬렉션은 조회한 루트 데이터를 루프에 돌릴 때 조회해 채우는 방식
  - 쿼리: 루트 1번, 컬렉션 N번
- v5
  - JPA에서 DTO로 직접 조회해 DTO로 반환
  - toOne 관계인 루트는 바로 조회
  - toMany 관계인 컬렉션은 따로 한 꺼번에 조회해 온 뒤 루프를 돌며 루트 데이터를 채우는 방식
  - 쿼리: 루트 1번, 컬렉션 1번
- v6
  - JPA에서 DTO로 직접 조회해 DTO로 반환
  - 모든 필드를 조인해 한 번에 가져오는 방식
  - 한계: 페이징이 불가하다. 
  - 쿼리: 1번
- 권장 개발 순서
  - 1. 엔티티 조회 -> 엔티티 조회 + 쿼리 최적화 + 컬렉션 최적화 
  - 2. DTO 조회 
  - 3. NativeSQL or 스프링 JdbcTemplate

## 📸 
<!-- gif or mp4 용량 제한 있음 -->

## Related Issue
- Resolved: #11

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->