### PR TITLE
#13 API 고급 - 실무 필수 최적화 

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/api/MemberApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/MemberApiController.java
@@ -25,7 +25,7 @@ public class MemberApiController {
     public CreateMemberResponse saveMemberV1(@RequestBody @Valid Member member){
         // @RequestBody : JSON으로 온 body를 Member에 그대로 매핑해서 넣어준다.
 
-        Long id = memberService.join(member);
+        Long id = memberService.join(member); // OSIV OFF라면 이렇게 반환된 후엔 영속성 컨텍스트도 끝, 데이터베이스 커넥션도 끝
         return new CreateMemberResponse(id);
     }
 

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -10,6 +10,7 @@ import jpabook.jpashop.repository.order.query.OrderItemQueryDto;
 import jpabook.jpashop.repository.order.query.OrderQueryDto;
 import jpabook.jpashop.repository.order.query.OrderQueryRepository;
 import jpabook.jpashop.repository.OrderSearch;
+import jpabook.jpashop.service.query.OrderQueryService;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -62,21 +63,14 @@ public class OrderApiController {
         return result;
     }
 
+    private final OrderQueryService orderQueryService;
+
     // 엔티티를 조회해 DTO로 반환
     // 쿼리 수 최적화 + 페이징 X
     // 컬렉션까지 한 번에 fetch join
     @GetMapping("/api/v3/orders")
-    public List<OrderDto> ordersV3() {
-        List<Order> orders = orderRepository.findAllWithItem();
-
-        for (Order order : orders) {
-            System.out.println("order ref="+ order + " id="+ order.getId());
-        }
-        List<OrderDto> result = orders.stream()
-                .map(o -> new OrderDto(o))
-                .collect(toList());
-
-        return result;
+    public List<jpabook.jpashop.service.query.OrderDto> ordersV3() {
+        return orderQueryService.ordersV3();
     }
 
     // 엔티티를 조회해 DTO로 반환

--- a/jpashop/src/main/java/jpabook/jpashop/service/MemberService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/MemberService.java
@@ -41,6 +41,8 @@ public class MemberService {
      * 회원 가입
      */
     @Transactional // 읽기 전용인 기능이 많으니까 전체를 readOnly = true로 해두고 이 기능만 false로
+    // 영속성 컨텍스트 만들어지고 데이터베이스 커넥션 가져오고
+    // OSIV OFF라면 로직이 끝난 후 데이터 베이스 커넥션 플러시 커밋하고 영속성 컨텍스트를 없애고 데이터 베이스 커넥션 반환
     public Long join(Member member){
         validateDuplicateMember(member); // 중복 회원 검증
         memberRepository.save(member);

--- a/jpashop/src/main/java/jpabook/jpashop/service/query/OrderDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/query/OrderDto.java
@@ -1,0 +1,42 @@
+package jpabook.jpashop.service.query;
+
+import jpabook.jpashop.api.OrderApiController;
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderItem;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Getter
+public class OrderDto {
+
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+        private List<OrderItemDto> orderItems;
+        // List<OrderItem>이면 DTO 안에 엔티티가 있는 상황.
+        // 엔티티에 대한 의존을 완전히 끊어야 한다.
+        // OrderItem도 DTO로 바꿔야 한다.
+
+        public OrderDto(Order order) {
+            orderId = order.getId();
+            name = order.getMember().getName();
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress();
+            orderItems = order.getOrderItems().stream()
+                    .map(orderItem -> new OrderItemDto(orderItem))
+                    .collect(toList());
+        }
+    }
+
+
+

--- a/jpashop/src/main/java/jpabook/jpashop/service/query/OrderItemDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/query/OrderItemDto.java
@@ -1,0 +1,17 @@
+package jpabook.jpashop.service.query;
+
+import jpabook.jpashop.domain.OrderItem;
+import lombok.Getter;
+
+@Getter
+class OrderItemDto {
+
+    private String itemName;
+    private int orderPrice;
+    private int count;
+    public OrderItemDto(OrderItem orderItem) {
+        itemName = orderItem.getItem().getName();
+        orderPrice = orderItem.getOrderPrice();
+        count = orderItem.getCount();
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/service/query/OrderQueryService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/query/OrderQueryService.java
@@ -1,0 +1,31 @@
+package jpabook.jpashop.service.query;
+
+import jpabook.jpashop.api.OrderApiController;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderQueryService {
+    private final OrderRepository orderRepository;
+    public List<OrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithItem();
+
+        for (Order order : orders) {
+            System.out.println("order ref="+ order + " id="+ order.getId());
+        }
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(toList());
+
+        return result;
+    }
+}

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
     driver-class-name: org.h2.Driver
 
   jpa:
+#    open-in-view: false
     hibernate:
       ddl-auto: create
     # create : 애플리케이션 실행 시점에 테이블 드롭하고 다시 만든다.


### PR DESCRIPTION
## Overview
- 트래픽이 많은 서비스의 경우 발생할 수 있는 성능 장애 문제와 관련된 개념인 OSIV 및 이를 켜고 끌 경우의 장단점을 이해하고 서비스의 특성에 따른 OSIV 관련 옵션 선택 로직 정리한다.

## Contents
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 배경 이해
  - 서비스에서 트랜잭션 시작. (`@Transactional` -> set auto commit false )
  - 트랜잭션 시작 -> 데이터 베이스 커넥션 가져온다. (디비에 트랜잭션 시작한다고 알린다.)
- OSIV의 개념
  - Open Session In View (Open EntityManager In View)
  - JPA : EntityManager = Hibernate : Session
  - 하지만 관례상 JPA에서도 Hibernate 경우와 동일하게 OSIV라 칭한다. 또는 open-in-view
- open-in-view: true
  - default. -> 애플리케이션 실행 시 터미널에 위 사실을 알려주며 경고를 띄운다. 즉 잘못 사용하면 위험함을 암시하는 것. 
  - 왜 위험한가?
    - open-in-view가 true라는 것은 트랙잭션의 범위를 벗어나더라도 영속성 컨텍스트를 끝까지 유지하는 것을 말한다. (`@Transactional` 해당되는 부분이 끝나도 반환을 안 한다. ) API의 경우 API가 유저에게 반환될 때까지, 화면인 경우 뷰템플릿을 갖고 렌더링이 완성되고 데이터 리스폰스가 나갈 때까지. 이의 위험성은 너무 오랫동안 데이터베이스 커넥션 리소스를 사용해 장애로 이어질 수 있기 때문이다. 이는 실시간 트래픽이 중요한 애플리케이션에서 장애로 많이 나타난다. 컨트롤러에서 외부 API를 호출하는 경우 외부 API 대기 시간 동안에도 커넥션 리소스를 반환하지 못하고 유지 해야 하는 경우에서도 마찬가지로 문제가 된다. 
  - 그럼 아예 끄면 되는 거 아닌가? 켜둔 이유가 무엇인가
    - 지연로딩을 위해서이다. 지연로딩을 하기 위해서는 영속성 컨텍스트가 살아있어야 한다. 이를 위해 true로 설정한 채 코드를 작성해 왔던 것. 즉 이를 켠다면 엔티티를 적극 활용해 레이지 로딩같은 기술을 컨트롤러, 뷰에서 활용하는 것이 가능해진다는 장점이 있다. 
- open-in-view: false
  - 실시간 트래픽이 많은 api 작성 시엔 장애를 막기 위해 이를 꺼야 한다. 근데 이때 지연로딩을 해야 할 경우는 어떻게 해야 할까
    - 여러 방법이 있지만 대표적으로 query service를 따로 작성하여 관리하는 방법이 있다. 즉 커맨드와 쿼리를 분리하는 것. 단 이럴 경우 코드와 계층 분리, 패키지 관리가 복잡해지는 단점이 발생한다. 
- 간단하게 정리하면 유지보수 측면에선 OSIV를 켜는 것이, 성능 측면에선 끄는 것이 적절하다고 말할 수 있다. api의 라이프사이클에 따라, 서비스의 규모 및 성격에 따라, admin api 여부 등에 따라 적절히 판단하여 OSIV on/off, query 서비스 분리 등을 통해 성능을 개선/ 장애 해결을 할 수 있다. 

## Related Issue
- Resolved: #13

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->