### PR TITLE
#14 스프링 데이터 JPA, QueryDSL 개요

### DIFF
--- a/jpashop/build.gradle
+++ b/jpashop/build.gradle
@@ -1,8 +1,16 @@
+buildscript {
+	dependencies {
+		classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:1.0.10")
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.6'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
+
+apply plugin: "com.ewerk.gradle.plugins.querydsl"
 
 group = 'jpabook'
 version = '0.0.1-SNAPSHOT'
@@ -46,9 +54,31 @@ dependencies {
 	testImplementation("org.junit.vintage:junit-vintage-engine") {
 		exclude group: "org.hamcrest", module: "hamcrest-core"
 	}
+
+	implementation 'com.querydsl:querydsl-jpa'
+	implementation 'com.querydsl:querydsl-apt'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
 
+def querydslDir = "src/main/generated/querydsl"
+querydsl {
+	library = "com.querydsl:querydsl-apt"
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main {
+		java {
+			srcDirs = ['src/main/java', querydslDir]
+		}
+	}
+}
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QAddress.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QAddress.java
@@ -1,0 +1,41 @@
+package jpabook.jpashop.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAddress is a Querydsl query type for Address
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAddress extends BeanPath<Address> {
+
+    private static final long serialVersionUID = 1648827089L;
+
+    public static final QAddress address = new QAddress("address");
+
+    public final StringPath city = createString("city");
+
+    public final StringPath street = createString("street");
+
+    public final StringPath zipcode = createString("zipcode");
+
+    public QAddress(String variable) {
+        super(Address.class, forVariable(variable));
+    }
+
+    public QAddress(Path<? extends Address> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAddress(PathMetadata metadata) {
+        super(Address.class, metadata);
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QCategory.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QCategory.java
@@ -1,0 +1,57 @@
+package jpabook.jpashop.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCategory is a Querydsl query type for Category
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCategory extends EntityPathBase<Category> {
+
+    private static final long serialVersionUID = 843258305L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCategory category = new QCategory("category");
+
+    public final ListPath<Category, QCategory> child = this.<Category, QCategory>createList("child", Category.class, QCategory.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<Category, QCategory> items = this.<Category, QCategory>createList("items", Category.class, QCategory.class, PathInits.DIRECT2);
+
+    public final StringPath name = createString("name");
+
+    public final QCategory parent;
+
+    public QCategory(String variable) {
+        this(Category.class, forVariable(variable), INITS);
+    }
+
+    public QCategory(Path<? extends Category> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCategory(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCategory(PathMetadata metadata, PathInits inits) {
+        this(Category.class, metadata, inits);
+    }
+
+    public QCategory(Class<? extends Category> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parent = inits.isInitialized("parent") ? new QCategory(forProperty("parent"), inits.get("parent")) : null;
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QDelivery.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QDelivery.java
@@ -1,0 +1,56 @@
+package jpabook.jpashop.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDelivery is a Querydsl query type for Delivery
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDelivery extends EntityPathBase<Delivery> {
+
+    private static final long serialVersionUID = 1616214199L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QDelivery delivery = new QDelivery("delivery");
+
+    public final QAddress address;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QOrder order;
+
+    public final EnumPath<DeliveryStatus> status = createEnum("status", DeliveryStatus.class);
+
+    public QDelivery(String variable) {
+        this(Delivery.class, forVariable(variable), INITS);
+    }
+
+    public QDelivery(Path<? extends Delivery> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QDelivery(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QDelivery(PathMetadata metadata, PathInits inits) {
+        this(Delivery.class, metadata, inits);
+    }
+
+    public QDelivery(Class<? extends Delivery> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new QAddress(forProperty("address")) : null;
+        this.order = inits.isInitialized("order") ? new QOrder(forProperty("order"), inits.get("order")) : null;
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QMember.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QMember.java
@@ -1,0 +1,55 @@
+package jpabook.jpashop.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -571917283L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMember member = new QMember("member1");
+
+    public final QAddress address;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final ListPath<Order, QOrder> orders = this.<Order, QOrder>createList("orders", Order.class, QOrder.class, PathInits.DIRECT2);
+
+    public QMember(String variable) {
+        this(Member.class, forVariable(variable), INITS);
+    }
+
+    public QMember(Path<? extends Member> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMember(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMember(PathMetadata metadata, PathInits inits) {
+        this(Member.class, metadata, inits);
+    }
+
+    public QMember(Class<? extends Member> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new QAddress(forProperty("address")) : null;
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QOrder.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QOrder.java
@@ -1,0 +1,60 @@
+package jpabook.jpashop.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QOrder is a Querydsl query type for Order
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOrder extends EntityPathBase<Order> {
+
+    private static final long serialVersionUID = 1369250155L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QOrder order = new QOrder("order1");
+
+    public final QDelivery delivery;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    public final DateTimePath<java.time.LocalDateTime> orderDate = createDateTime("orderDate", java.time.LocalDateTime.class);
+
+    public final ListPath<OrderItem, QOrderItem> orderItems = this.<OrderItem, QOrderItem>createList("orderItems", OrderItem.class, QOrderItem.class, PathInits.DIRECT2);
+
+    public final EnumPath<OrderStatus> status = createEnum("status", OrderStatus.class);
+
+    public QOrder(String variable) {
+        this(Order.class, forVariable(variable), INITS);
+    }
+
+    public QOrder(Path<? extends Order> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QOrder(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QOrder(PathMetadata metadata, PathInits inits) {
+        this(Order.class, metadata, inits);
+    }
+
+    public QOrder(Class<? extends Order> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.delivery = inits.isInitialized("delivery") ? new QDelivery(forProperty("delivery"), inits.get("delivery")) : null;
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QOrderItem.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/QOrderItem.java
@@ -1,0 +1,58 @@
+package jpabook.jpashop.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QOrderItem is a Querydsl query type for OrderItem
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOrderItem extends EntityPathBase<OrderItem> {
+
+    private static final long serialVersionUID = -1586537698L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QOrderItem orderItem = new QOrderItem("orderItem");
+
+    public final NumberPath<Integer> count = createNumber("count", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final jpabook.jpashop.domain.item.QItem item;
+
+    public final QOrder order;
+
+    public final NumberPath<Integer> orderPrice = createNumber("orderPrice", Integer.class);
+
+    public QOrderItem(String variable) {
+        this(OrderItem.class, forVariable(variable), INITS);
+    }
+
+    public QOrderItem(Path<? extends OrderItem> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QOrderItem(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QOrderItem(PathMetadata metadata, PathInits inits) {
+        this(OrderItem.class, metadata, inits);
+    }
+
+    public QOrderItem(Class<? extends OrderItem> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.item = inits.isInitialized("item") ? new jpabook.jpashop.domain.item.QItem(forProperty("item")) : null;
+        this.order = inits.isInitialized("order") ? new QOrder(forProperty("order"), inits.get("order")) : null;
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QAlbum.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QAlbum.java
@@ -1,0 +1,56 @@
+package jpabook.jpashop.domain.item;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAlbum is a Querydsl query type for Album
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAlbum extends EntityPathBase<Album> {
+
+    private static final long serialVersionUID = 521107351L;
+
+    public static final QAlbum album = new QAlbum("album");
+
+    public final QItem _super = new QItem(this);
+
+    public final StringPath artist = createString("artist");
+
+    //inherited
+    public final ListPath<jpabook.jpashop.domain.Category, jpabook.jpashop.domain.QCategory> categories = _super.categories;
+
+    public final StringPath etc = createString("etc");
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final StringPath name = _super.name;
+
+    //inherited
+    public final NumberPath<Integer> price = _super.price;
+
+    //inherited
+    public final NumberPath<Integer> stockQuantity = _super.stockQuantity;
+
+    public QAlbum(String variable) {
+        super(Album.class, forVariable(variable));
+    }
+
+    public QAlbum(Path<? extends Album> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAlbum(PathMetadata metadata) {
+        super(Album.class, metadata);
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QBook.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QBook.java
@@ -1,0 +1,56 @@
+package jpabook.jpashop.domain.item;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBook is a Querydsl query type for Book
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBook extends EntityPathBase<Book> {
+
+    private static final long serialVersionUID = -1091535679L;
+
+    public static final QBook book = new QBook("book");
+
+    public final QItem _super = new QItem(this);
+
+    public final StringPath author = createString("author");
+
+    //inherited
+    public final ListPath<jpabook.jpashop.domain.Category, jpabook.jpashop.domain.QCategory> categories = _super.categories;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final StringPath isbn = createString("isbn");
+
+    //inherited
+    public final StringPath name = _super.name;
+
+    //inherited
+    public final NumberPath<Integer> price = _super.price;
+
+    //inherited
+    public final NumberPath<Integer> stockQuantity = _super.stockQuantity;
+
+    public QBook(String variable) {
+        super(Book.class, forVariable(variable));
+    }
+
+    public QBook(Path<? extends Book> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBook(PathMetadata metadata) {
+        super(Book.class, metadata);
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QItem.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QItem.java
@@ -1,0 +1,46 @@
+package jpabook.jpashop.domain.item;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QItem is a Querydsl query type for Item
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QItem extends EntityPathBase<Item> {
+
+    private static final long serialVersionUID = -1091322645L;
+
+    public static final QItem item = new QItem("item");
+
+    public final ListPath<jpabook.jpashop.domain.Category, jpabook.jpashop.domain.QCategory> categories = this.<jpabook.jpashop.domain.Category, jpabook.jpashop.domain.QCategory>createList("categories", jpabook.jpashop.domain.Category.class, jpabook.jpashop.domain.QCategory.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final NumberPath<Integer> price = createNumber("price", Integer.class);
+
+    public final NumberPath<Integer> stockQuantity = createNumber("stockQuantity", Integer.class);
+
+    public QItem(String variable) {
+        super(Item.class, forVariable(variable));
+    }
+
+    public QItem(Path<? extends Item> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QItem(PathMetadata metadata) {
+        super(Item.class, metadata);
+    }
+
+}
+

--- a/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QMovie.java
+++ b/jpashop/src/main/generated/querydsl/jpabook/jpashop/domain/item/QMovie.java
@@ -1,0 +1,56 @@
+package jpabook.jpashop.domain.item;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMovie is a Querydsl query type for Movie
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMovie extends EntityPathBase<Movie> {
+
+    private static final long serialVersionUID = 532297816L;
+
+    public static final QMovie movie = new QMovie("movie");
+
+    public final QItem _super = new QItem(this);
+
+    public final StringPath actor = createString("actor");
+
+    //inherited
+    public final ListPath<jpabook.jpashop.domain.Category, jpabook.jpashop.domain.QCategory> categories = _super.categories;
+
+    public final StringPath director = createString("director");
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final StringPath name = _super.name;
+
+    //inherited
+    public final NumberPath<Integer> price = _super.price;
+
+    //inherited
+    public final NumberPath<Integer> stockQuantity = _super.stockQuantity;
+
+    public QMovie(String variable) {
+        super(Movie.class, forVariable(variable));
+    }
+
+    public QMovie(Path<? extends Movie> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMovie(PathMetadata metadata) {
+        super(Movie.class, metadata);
+    }
+
+}
+

--- a/jpashop/src/main/java/jpabook/jpashop/repository/MemberRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/MemberRepository.java
@@ -1,57 +1,11 @@
 package jpabook.jpashop.repository;
 
 import jpabook.jpashop.domain.Member;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.persistence.EntityManager;
 import java.util.List;
 
-@Repository // component 스케일에서 자동으로 스프링 빈으로 등록, 관리가 된다.
-@RequiredArgsConstructor
-public class MemberRepository {
-
-//    @PersistenceContext // JPA가 제공하는 표준 어노테이션
-//    @Autowired // EntityManager는 @PersistenceContext만 되는데, 스프링 부트 JPA를 쓰면 이걸로 바꾸기 가능
-    private final EntityManager em; // Entity Manager를 만들어서 주입해 준다.
-
-    // 만약 엔티티 매니저 팩토리를 주입하고 싶다면 아래 코드.
-    // 원래 순수 JPA를 쓰면 EntityManagerFactory에서 직접 EntityManager를 꺼내 써야 한다.
-//    @PersistenceUnit
-//    private EntityManagerFactory emf;
-
-    // @RequiredArgsConstructor 써줬으니까 자동으로 생성된다.
-    // public MemberRepository(EntityManager em){
-    //     this.em = em;
-    // }
-
-    public void save(Member member){
-        em.persist(member); // JPA가 저장
-        // 영속성 컨텍스트 안에 멤버 객체를 넣고
-        // 나중에 트랜잭션이 커밋되는 시점에 디비에 반영된다. insert 쿼리가 날아간다.
-    }
-
-    public Member findOne(Long id){
-        return em.find(Member.class, id); // 멤버 찾아서 반환 JPA의 find 메소드
-        // 단건 조회
-        // 타입, pk
-    }
-
-    public List<Member> findAll(){
-//        List<Member> result = em.createQuery("select m from Member m", Member.class);// jpql, 반환타입
-//                         .getResultList();
-//                         return result;
-
-        // 더 간결하게.
-        return em.createQuery("select m from Member m", Member.class)// jpql, 반환타입
-                         .getResultList();
-
-        // jpql : 문법은 sql과 거의 똑같지만 sql은 테이블을 대상으로 쿼리를 하는 것이고, jpql은 엔티티를 대상으로 쿼리한다.
-    }
-
-    public List<Member> findByName(String name){
-        return em.createQuery("select m from Member m where m.name = :name", Member.class)
-                .setParameter("name", name)
-                .getResultList();
-    }
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // select m from Member m where m.name = ?
+    List<Member> findByName(String name);
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/MemberRepositoryOld.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/MemberRepositoryOld.java
@@ -1,0 +1,57 @@
+package jpabook.jpashop.repository;
+
+import jpabook.jpashop.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository // component 스케일에서 자동으로 스프링 빈으로 등록, 관리가 된다.
+@RequiredArgsConstructor
+public class MemberRepositoryOld {
+
+//    @PersistenceContext // JPA가 제공하는 표준 어노테이션
+//    @Autowired // EntityManager는 @PersistenceContext만 되는데, 스프링 부트 JPA를 쓰면 이걸로 바꾸기 가능
+    private final EntityManager em; // Entity Manager를 만들어서 주입해 준다.
+
+    // 만약 엔티티 매니저 팩토리를 주입하고 싶다면 아래 코드.
+    // 원래 순수 JPA를 쓰면 EntityManagerFactory에서 직접 EntityManager를 꺼내 써야 한다.
+//    @PersistenceUnit
+//    private EntityManagerFactory emf;
+
+    // @RequiredArgsConstructor 써줬으니까 자동으로 생성된다.
+    // public MemberRepository(EntityManager em){
+    //     this.em = em;
+    // }
+
+    public void save(Member member){
+        em.persist(member); // JPA가 저장
+        // 영속성 컨텍스트 안에 멤버 객체를 넣고
+        // 나중에 트랜잭션이 커밋되는 시점에 디비에 반영된다. insert 쿼리가 날아간다.
+    }
+
+    public Member findOne(Long id){
+        return em.find(Member.class, id); // 멤버 찾아서 반환 JPA의 find 메소드
+        // 단건 조회
+        // 타입, pk
+    }
+
+    public List<Member> findAll(){
+//        List<Member> result = em.createQuery("select m from Member m", Member.class);// jpql, 반환타입
+//                         .getResultList();
+//                         return result;
+
+        // 더 간결하게.
+        return em.createQuery("select m from Member m", Member.class)// jpql, 반환타입
+                         .getResultList();
+
+        // jpql : 문법은 sql과 거의 똑같지만 sql은 테이블을 대상으로 쿼리를 하는 것이고, jpql은 엔티티를 대상으로 쿼리한다.
+    }
+
+    public List<Member> findByName(String name){
+        return em.createQuery("select m from Member m where m.name = :name", Member.class)
+                .setParameter("name", name)
+                .getResultList();
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -1,6 +1,9 @@
 package jpabook.jpashop.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.QMember;
+import jpabook.jpashop.domain.QOrder;
 import jpabook.jpashop.repository.order.simplequery.SimpleOrderQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -99,6 +102,19 @@ public class OrderRepository {
         cq.where(cb.and(criteria.toArray(new Predicate[criteria.size()])));
         TypedQuery<Order> query = em.createQuery(cq).setMaxResults(1000); //최대 1000건
         return query.getResultList();
+    }
+
+    public List<Order> findAll(OrderSearch orderSearch) {
+        QOrder order = QOrder.order;
+        QMember member = QMember.member;
+
+        JPAQueryFactory query = new JPAQueryFactory(em);
+        return query
+                .select(order)
+                .from(order)
+                .join(order.member, member)
+                .limit(1000)
+                .fetch();
     }
 
     public List<Order> findAllWithMemberDelivery() {

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.domain.QMember;
 import jpabook.jpashop.domain.QOrder;
 import jpabook.jpashop.repository.order.simplequery.SimpleOrderQueryDto;
@@ -105,16 +107,25 @@ public class OrderRepository {
     }
 
     public List<Order> findAll(OrderSearch orderSearch) {
+        JPAQueryFactory query = new JPAQueryFactory(em);
         QOrder order = QOrder.order;
         QMember member = QMember.member;
 
-        JPAQueryFactory query = new JPAQueryFactory(em);
+
         return query
                 .select(order)
                 .from(order)
                 .join(order.member, member)
+                .where(statusEq(orderSearch.getOrderStatus()), member.name.like(orderSearch.getMemberName()))
                 .limit(1000)
                 .fetch();
+    }
+
+    private BooleanExpression statusEq(OrderStatus statusCond) {
+        if (statusCond == null) {
+            return null;
+        }
+        return QOrder.order.status.eq(statusCond);
     }
 
     public List<Order> findAllWithMemberDelivery() {

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -21,10 +21,15 @@ import static jpabook.jpashop.domain.QMember.member;
 import static jpabook.jpashop.domain.QOrder.order;
 
 @Repository // JPA를 직접 사용하는 계층, 엔티티 매니저 사용
-@RequiredArgsConstructor
 public class OrderRepository {
 
     private final EntityManager em;
+    private final JPAQueryFactory query;
+
+    public OrderRepository(EntityManager em) {
+        this.em = em;
+        this.query = new JPAQueryFactory(em);
+    }
 
     public void save(Order order){
         em.persist(order);
@@ -110,8 +115,6 @@ public class OrderRepository {
     }
 
     public List<Order> findAll(OrderSearch orderSearch) {
-        JPAQueryFactory query = new JPAQueryFactory(em);
-
         return query
                 .select(order)
                 .from(order)

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -116,9 +116,17 @@ public class OrderRepository {
                 .select(order)
                 .from(order)
                 .join(order.member, member)
-                .where(statusEq(orderSearch.getOrderStatus()), member.name.like(orderSearch.getMemberName()))
+                .where(statusEq(orderSearch.getOrderStatus()), nameLike(orderSearch.getMemberName(), member))
                 .limit(1000)
                 .fetch();
+    }
+
+
+    private BooleanExpression nameLike(String nameCond, QMember member) {
+        if (!StringUtils.hasText(nameCond)) {
+            return null;
+        }
+        return member.name.like(nameCond);
     }
 
     private BooleanExpression statusEq(OrderStatus statusCond) {

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -17,6 +17,9 @@ import javax.persistence.criteria.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jpabook.jpashop.domain.QMember.member;
+import static jpabook.jpashop.domain.QOrder.order;
+
 @Repository // JPA를 직접 사용하는 계층, 엔티티 매니저 사용
 @RequiredArgsConstructor
 public class OrderRepository {
@@ -108,9 +111,6 @@ public class OrderRepository {
 
     public List<Order> findAll(OrderSearch orderSearch) {
         JPAQueryFactory query = new JPAQueryFactory(em);
-        QOrder order = QOrder.order;
-        QMember member = QMember.member;
-
 
         return query
                 .select(order)
@@ -133,7 +133,7 @@ public class OrderRepository {
         if (statusCond == null) {
             return null;
         }
-        return QOrder.order.status.eq(statusCond);
+        return order.status.eq(statusCond);
     }
 
     public List<Order> findAllWithMemberDelivery() {

--- a/jpashop/src/main/java/jpabook/jpashop/service/MemberService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/MemberService.java
@@ -69,12 +69,12 @@ public class MemberService {
      * 회원 한 명 조회
      */
     public Member findOne(Long memberId){
-        return memberRepository.findOne(memberId);
+        return memberRepository.findById(memberId).get();
     }
 
     @Transactional
     public void update(Long id, String name) {
-        Member member = memberRepository.findOne(id);
+        Member member = memberRepository.findById(id).get();
         member.setName(name);
         // member를 반환할 수도 있지만 그렇게 되면 커맨드와 쿼리를 한 메소드 안에서 하는 게 된다.
         // id 정도만 반환하거나 아예 반환하지 않는 게 깔끔하다.

--- a/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
@@ -36,7 +36,7 @@ public class OrderService {
     public Long order(Long memberId, Long itemId, int count){
 
         // 엔티티 조회
-        Member member = memberRepository.findOne(memberId);
+        Member member = memberRepository.findById(memberId).get();
         Item item = itemRepository.findOne(itemId);
 
         // 배송정보 생성

--- a/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
@@ -72,7 +72,7 @@ public class OrderService {
      * 검색
      */
     public List<Order> findOrders(OrderSearch orderSearch){
-        return orderRepository.findAllByString(orderSearch);
+        return orderRepository.findAll(orderSearch);
         // 이렇게 단순 위임만 하는 코드의 경우는 서비스 코드는 생략하고 컨트롤러에서 레포지토리 접근하게 해도 된다.
     }
 }


### PR DESCRIPTION
## Overview
- 스프링 데이터 JPA 
- QueryDSL

## Contents
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 스프링 데이터 JPA: JPA를 사용할 때 지루하게 반복하는 코드를 자동화해준다. 
  - 라이브러리: spring boot starter data jpa
  - JpaRepository<엔티티, id 타입>
  - save, saveAll, findById, findAll 등 공통화할 수 있는 건 다 만들어져 있다. 그냥 쓰면 된다. 
  - findByName으로 만들면 select m from Member m where m.name = :name 인 jpql을 만들어준다. 
  - 기본적인 CRUD 기능이 모두 제공된다. 
  - 개발자는 인터페이스만 만들면 되며 구현체는 스프링 데이터 JPA가 어플리케이션 실행시점에 주입해준다. 
- QueryDSL: JPA를 Java 코드로 작성할 수 있게 해준다. 작성한 코드는 jpql로 바뀌어 실행된다. 
  - 장점: 
    - 읽고 쓰기가 편하다. 직관적인 문법
    - code assistant가 된다. 
    - 쿼리 오류 해결(오타 잡기 등)이 컴파일 시점에 가능하다. 
      - 원래는 사용자가 돌려 봐야만 알 수가 있다. 
    - 코드의 재사용성이 좋다. 
    - DTO 변환 조회가 깔끔하다. 
## Related Issue
- Resolved: #14

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->